### PR TITLE
Add simple course viewer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# course_viewer
-Course Viewer
+# Course Viewer
+
+A simple web application to browse HTML pages and video files from a directory.
+It scans the given directory on first run and stores the structure in a SQLite
+database. User progress (last opened file) is stored per user.
+
+## Running
+
+### Development
+
+```bash
+pip install -r requirements.txt
+python -m app.server
+```
+
+### Docker
+
+Build and start the application together with nginx using `docker-compose`:
+
+```bash
+docker-compose up --build
+```
+
+The web interface will be available on <http://localhost:8080>.
+
+By default it serves files from the `files` directory and creates a default
+user `admin` with password `admin`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,140 @@
+import os
+import uuid
+
+from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from .models import Base, File, User, Progress
+
+DB_PATH = os.environ.get('COURSE_DB', 'course.db')
+FILES_DIR = os.environ.get('COURSE_DIR', 'files')
+
+tokens = {}
+
+def create_app():
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    engine = create_engine(f"sqlite:///{DB_PATH}")
+    Base.metadata.create_all(engine)
+
+    def get_db():
+        db = Session(engine)
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def scan():
+        db = Session(engine)
+        if db.query(File).first():
+            db.close()
+            return
+        for root, dirs, files in os.walk(FILES_DIR):
+            rel_root = os.path.relpath(root, FILES_DIR)
+            parent = db.query(File).filter(File.path == rel_root).first()
+            if not parent:
+                parent_name = os.path.basename(root) or rel_root
+                parent = File(name=parent_name, path=rel_root, parent_id=None, is_dir=True)
+                db.add(parent)
+                db.commit()
+            for order, d in enumerate(sorted(dirs)):
+                dir_path = os.path.join(rel_root, d)
+                db.add(File(name=d, path=dir_path, parent_id=parent.id, is_dir=True, order=order))
+            for order, f in enumerate(sorted(files)):
+                file_path = os.path.join(rel_root, f)
+                db.add(File(name=f, path=file_path, parent_id=parent.id, is_dir=False, order=order))
+            db.commit()
+        db.close()
+
+    scan()
+
+    def ensure_user():
+        db = Session(engine)
+        if not db.query(User).filter_by(username="admin").first():
+            db.add(User(username="admin", password_hash=generate_password_hash("admin")))
+            db.commit()
+        db.close()
+
+    ensure_user()
+
+    async def get_current_user(request: Request):
+        token = request.headers.get("Authorization")
+        if not token or token not in tokens:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        return tokens[token]
+
+    @app.post("/api/login")
+    def login(data: dict, db: Session = Depends(get_db)):
+        username = data.get("username")
+        password = data.get("password")
+        user = db.query(User).filter_by(username=username).first()
+        if not user or not check_password_hash(user.password_hash, password):
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+        token = str(uuid.uuid4())
+        tokens[token] = user.id
+        return {"token": token}
+
+    def build_tree(db: Session, parent_id=None):
+        nodes = db.query(File).filter_by(parent_id=parent_id).order_by(File.order).all()
+        result = []
+        for node in nodes:
+            item = {"id": node.id, "name": node.name, "is_dir": node.is_dir, "path": node.path}
+            if node.is_dir:
+                item["children"] = build_tree(db, node.id)
+            result.append(item)
+        return result
+
+    @app.get("/api/files")
+    def get_files(user_id: int = Depends(get_current_user), db: Session = Depends(get_db)):
+        return build_tree(db)
+
+    @app.get("/api/progress")
+    def get_progress(user_id: int = Depends(get_current_user), db: Session = Depends(get_db)):
+        progress = db.query(Progress).filter_by(user_id=user_id).first()
+        return {"file_id": progress.file_id if progress else None}
+
+    @app.post("/api/progress")
+    def set_progress(data: dict, user_id: int = Depends(get_current_user), db: Session = Depends(get_db)):
+        file_id = data.get("file_id")
+        progress = db.query(Progress).filter_by(user_id=user_id).first()
+        if progress:
+            progress.file_id = file_id
+        else:
+            progress = Progress(user_id=user_id, file_id=file_id)
+            db.add(progress)
+        db.commit()
+        return {"status": "ok"}
+
+
+
+    @app.get("/api/next/{file_id}")
+    def next_file(file_id: int, user_id: int = Depends(get_current_user), db: Session = Depends(get_db)):
+        current = db.query(File).filter_by(id=file_id).first()
+        if not current:
+            return {"file_id": None}
+        siblings = (
+            db.query(File)
+            .filter_by(parent_id=current.parent_id, is_dir=False)
+            .order_by(File.order)
+            .all()
+        )
+        next_id = None
+        for idx, s in enumerate(siblings):
+            if s.id == current.id and idx + 1 < len(siblings):
+                next_id = siblings[idx + 1].id
+                break
+        return {"file_id": next_id}
+
+    app.mount("/files", StaticFiles(directory=FILES_DIR), name="files")
+    app.mount("/", StaticFiles(directory="app/static", html=True), name="static")
+
+    return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+class File(Base):
+    __tablename__ = 'files'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    path = Column(String, nullable=False)
+    parent_id = Column(Integer, ForeignKey('files.id'))
+    is_dir = Column(Boolean, default=False)
+    order = Column(Integer, default=0)
+    children = relationship('File')
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    username = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+
+class Progress(Base):
+    __tablename__ = 'progress'
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    file_id = Column(Integer, ForeignKey('files.id'))

--- a/app/server.py
+++ b/app/server.py
@@ -1,0 +1,7 @@
+from . import create_app
+import uvicorn
+
+app = create_app()
+
+if __name__ == "__main__":
+    uvicorn.run("app.server:app", host="0.0.0.0", port=8000, reload=False)

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Course Viewer</title>
+    <style>
+        ul { list-style-type: none; }
+        .dir { font-weight: bold; }
+    </style>
+</head>
+<body>
+<div id="login">
+    <h2>Login</h2>
+    <input id="user" placeholder="username"><br>
+    <input id="pass" type="password" placeholder="password"><br>
+    <button onclick="login()">Login</button>
+    <div id="login-error"></div>
+</div>
+<div id="content" style="display:none;">
+    <h2>Files</h2>
+    <div id="tree"></div>
+    <iframe id="viewer" style="width:80%; height:500px;"></iframe>
+    <br>
+    <button onclick="nextFile()">Next</button>
+</div>
+<script>
+let token = '';
+let currentId = null;
+function login() {
+    fetch('/api/login', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({username:document.getElementById('user').value, password:document.getElementById('pass').value})
+    }).then(r=>r.json()).then(d=>{
+        if(d.token){
+            token = d.token;
+            document.getElementById('login').style.display='none';
+            document.getElementById('content').style.display='block';
+            loadFiles();
+        } else {
+            document.getElementById('login-error').innerText='Invalid credentials';
+        }
+    });
+}
+function loadFiles(){
+    fetch('/api/files',{headers:{'Authorization':token}}).then(r=>r.json()).then(d=>{
+        document.getElementById('tree').appendChild(renderTree(d));
+        fetch('/api/progress',{headers:{'Authorization':token}}).then(r=>r.json()).then(p=>{
+            if(p.file_id){ openFileId(p.file_id); }
+        });
+    });
+}
+function renderTree(nodes){
+    const ul = document.createElement('ul');
+    nodes.forEach(n=>{
+        const li = document.createElement('li');
+        li.textContent = n.name;
+        if(n.is_dir){
+            li.className='dir';
+            li.appendChild(renderTree(n.children));
+        } else {
+            idPath[n.id]=n.path;
+            li.onclick=()=>openFileId(n.id);
+        }
+        ul.appendChild(li);
+    });
+    return ul;
+}
+function openFileId(id){
+    currentId = id;
+    const path = idPath[id];
+    document.getElementById('viewer').src = '/files/' + path;
+    fetch('/api/progress',{method:'POST',headers:{'Content-Type':'application/json','Authorization':token},body:JSON.stringify({file_id:id})});
+}
+function nextFile(){
+    fetch('/api/progress',{headers:{'Authorization':token}}).then(r=>r.json()).then(p=>{
+        const id = p.file_id;
+        fetch('/api/next/'+id,{headers:{'Authorization':token}}).then(r=>r.json()).then(n=>{
+            if(n.file_id){ openFileId(n.file_id); }
+        });
+    });
+}
+const idPath={};
+</script>
+</body>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  app:
+    build: .
+    volumes:
+      - ./course.db:/app/course.db
+      - ./files:/app/files
+    environment:
+      - COURSE_DIR=/app/files
+      - COURSE_DB=/app/course.db
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./app/static:/usr/share/nginx/html
+      - ./files:/usr/share/nginx/html/files
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - app

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,15 @@
+events {}
+http {
+    server {
+        listen 80;
+        location /api/ {
+            proxy_pass http://app:8000/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+        location / {
+            root /usr/share/nginx/html;
+            try_files $uri /index.html;
+        }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+SQLAlchemy
+Werkzeug


### PR DESCRIPTION
## Summary
- implement a FastAPI backend to scan a folder of HTML and video files
- store structure and user progress in SQLite
- update frontend to load files directly from nginx
- add Dockerfile, nginx config and docker-compose setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d3b7224bc8320b2249235b6b8f9ee