### PR TITLE
Improve course viewer layout

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,17 +5,22 @@
     <title>Course Viewer</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
+        html,body{height:100%;}
         ul { list-style-type: none; padding-left: 1rem; }
+        summary{cursor:pointer;}
         .dir { font-weight: bold; }
-        #layout{display:flex;}
-        #sidebar{width:250px;overflow-y:auto;}
+        #content{height:100%;display:flex;flex-direction:column;}
+        #layout{display:flex;flex:1;overflow:hidden;}
+        #sidebar{width:250px;overflow-y:auto;height:100%;flex-shrink:0;}
+        #main{flex-grow:1;overflow:auto;display:flex;flex-direction:column;}
+        #viewer{flex-grow:1;}
         @media (max-width: 768px){
             #sidebar{position:absolute;left:0;top:0;bottom:0;background:#fff;padding:1rem;transform:translateX(-100%);transition:transform .3s;width:250px;z-index:1000;}
             #sidebar.show{transform:translateX(0);}
         }
     </style>
 </head>
-<body class="container-fluid py-4">
+<body class="container-fluid py-4" style="height:100vh;">
 <div id="login">
     <h2 class="mb-3">Login</h2>
     <div class="mb-2"><input class="form-control" id="user" placeholder="username"></div>
@@ -31,7 +36,7 @@
             <div id="tree"></div>
         </div>
         <div id="main" class="flex-grow-1 ps-3">
-            <div id="viewer" style="min-height:500px;"></div>
+            <div id="viewer"></div>
             <br>
             <button class="btn btn-secondary mt-2" onclick="nextFile()">Next</button>
         </div>
@@ -68,11 +73,16 @@ function renderTree(nodes){
     const ul = document.createElement('ul');
     nodes.forEach(n=>{
         const li = document.createElement('li');
-        li.textContent = n.name;
         if(n.is_dir){
-            li.className='dir';
-            li.appendChild(renderTree(n.children));
+            const details = document.createElement('details');
+            const summary = document.createElement('summary');
+            summary.textContent = n.name;
+            summary.className = 'dir';
+            details.appendChild(summary);
+            details.appendChild(renderTree(n.children));
+            li.appendChild(details);
         } else {
+            li.textContent = n.name;
             idPath[n.id]=n.path;
             li.onclick=()=>openFileId(n.id);
         }
@@ -86,11 +96,12 @@ function openFileId(id){
     const viewer = document.getElementById('viewer');
     viewer.innerHTML = '';
     const ext = path.split('.').pop().toLowerCase();
-    const url = '/files/' + path;
+    const url = '/files/' + path.split('/').map(encodeURIComponent).join('/');
     if(['mp4','webm','ogg'].includes(ext)){
         const v = document.createElement('video');
         v.controls = true;
-        v.className='w-100';
+        v.className='w-100 h-100';
+        v.style.objectFit='contain';
         v.src = url;
         viewer.appendChild(v);
     } else if(['png','jpg','jpeg','gif','bmp','webp'].includes(ext)){


### PR DESCRIPTION
## Summary
- stretch viewer to full-page height
- make sidebar scroll independently
- collapse folders in tree view
- fix video path encoding and layout

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_685d584cdde0832086db3eee03ca69f5