### PR TITLE
Fix sidebar height

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -11,7 +11,7 @@
         .dir { font-weight: bold; }
         #content{height:100%;display:flex;flex-direction:column;min-height:0;}
         #layout{display:flex;flex:1;overflow:hidden;min-height:0;}
-        #sidebar{width:250px;height:100%;flex-shrink:0;display:flex;flex-direction:column;}
+        #sidebar{width:250px;height:100vh;flex-shrink:0;display:flex;flex-direction:column;overflow-y:auto;}
         #tree{overflow-y:auto;flex:1;}
         #main{flex-grow:1;display:flex;flex-direction:column;overflow:hidden;min-height:0;}
         #viewer{flex-grow:1;overflow:auto;}


### PR DESCRIPTION
## Summary
- keep sidebar from stretching layout by setting `height:100vh`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d5e397ef883208cdee347a2bc4759