### PR TITLE
Move next button to floating circle

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -17,6 +17,7 @@
         #viewer{flex-grow:1;overflow:auto;}
         #tree li.active{background:#0d6efd33;}
         #sidebarToggle{position:fixed;top:1rem;left:1rem;z-index:1101;}
+        #nextButton{position:fixed;bottom:1rem;right:1rem;z-index:1101;width:3rem;height:3rem;border-radius:50%;display:flex;align-items:center;justify-content:center;}
         @media (max-width: 768px){
             #sidebar{position:absolute;left:0;top:0;bottom:0;background:#fff;padding:1rem;transform:translateX(-100%);transition:transform .3s;width:250px;z-index:1000;}
             #sidebar.show{transform:translateX(0);}
@@ -33,7 +34,7 @@
         </div>
         <div id="main" class="flex-grow-1 ps-3">
             <div id="viewer"></div>
-            <button class="btn btn-secondary mt-2" onclick="nextFile()">Next</button>
+            <button class="btn btn-secondary" id="nextButton" onclick="nextFile()">&rarr;</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- turn Next button into a floating circular control with an arrow icon

## Testing
- `python -m py_compile $(find . -name '*.py' -not -path './venv/*')`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d633395c0832097a460fe6d6f9999